### PR TITLE
Load todos after login

### DIFF
--- a/src/components/Login.js
+++ b/src/components/Login.js
@@ -1,15 +1,17 @@
 import { Authenticator, useAuthenticator } from '@aws-amplify/ui-react';
 import '@aws-amplify/ui-react/styles.css';
+import { useEffect } from 'react';
 import { useNavigate } from "react-router-dom";
 
 const Login = () => {
     const navigate = useNavigate();
     const { user } = useAuthenticator((context) => [context.user]);
 
-    if (user) {
-        navigate("/");
-    };
-
-    return <Authenticator>login</Authenticator>
+    useEffect(() => {
+        if (user) {
+            navigate("/");
+        };
+    }, [user, navigate])
+    return <Authenticator>Login...</Authenticator>
 };
 export default Login;

--- a/src/index.js
+++ b/src/index.js
@@ -14,6 +14,9 @@ const listener = async (data) => {
     case 'signOut':
       window.location.reload();
       break;
+    case 'signIn':
+      window.location.reload();
+      break;
     default:
   }
 };


### PR DESCRIPTION
This will force datastore to load todos after a user login. To enforce the load, we do a refresh after login.